### PR TITLE
Add '--version' and '--appVersion' arguments to building script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+#IntelliJ
+.idea


### PR DESCRIPTION
Add possibility to pass chart version and appVersion to helm package. It's beneficial for continuous delivery and allows having each chart unique.