### PR TITLE
Increase max file length for uploading index.yaml to infinity

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -120,7 +120,9 @@ class RemoteHelmRepo {
     async _uploadFile(filename, data, headers = {}) {
         try {
             await axios.put(`${this.repoConfig.repository}/${filename}`, data, {
-                headers: Object.assign({}, this._authHeaders(), headers)
+                headers: Object.assign({}, this._authHeaders(), headers),
+                'maxContentLength': Infinity,
+                'maxBodyLength': Infinity
             });
         } catch(e) {
             throw new Error(`Unable to upload ${filename}. ${e.message}: ${e.response.statusText}`);


### PR DESCRIPTION
We have issue where our index.yaml is too large (10mb), and upload fails because of it. 